### PR TITLE
add methods to guzzle proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7
 
 env:

--- a/src/Tests/Units/DependencyInjection/M6WebXRequestUidExtension.php
+++ b/src/Tests/Units/DependencyInjection/M6WebXRequestUidExtension.php
@@ -50,15 +50,14 @@ class M6WebXRequestUidExtension extends atoum\test
     public function testBasicConfiguration()
     {
         $this->initContainer('basic_config', true);
-
         $this
             ->boolean($this->container->has('test.guzzle1'))
                 ->isIdenticalTo(true)
             ->object($this->container->get('test.guzzle1'))
-                ->isInstanceOf('GuzzleHttp\Client')
+                ->isInstanceOf('GuzzleHttp\ClientInterface')
                 ->isInstanceOf('M6Web\Bundle\XRequestUidBundle\Guzzle\GuzzleProxy')
             ->object($this->container->get('test.guzzle2'))
-                ->isInstanceOf('GuzzleHttp\Client')
+                ->isInstanceOf('GuzzleHttp\ClientInterface')
                 ->isNotInstanceOf('M6Web\Bundle\XRequestUidBundle\Guzzle\GuzzleProxy') // guzzle2 is not decorated
         ;
     }


### PR DESCRIPTION
Fix erreur when use method request, send: Unsupported operand types
The config values was empty.

Add method request, requestAsync, sendAsync and send to guzzle proxy for add headers.