### PR TITLE
fix(GuzzleProxy): merge request options

### DIFF
--- a/src/Guzzle/GuzzleProxy.php
+++ b/src/Guzzle/GuzzleProxy.php
@@ -97,7 +97,7 @@ class GuzzleProxy implements ClientInterface
      */
     public function __call($method, $args)
     {
-        $options = array_merge($args[1] ?? [], $this->getOptions($method));
+        $options = array_merge_recursive($args[1] ?? [], $this->getOptions($method));
         $args[1] = $options;
 
         // forward the call to the client
@@ -113,7 +113,7 @@ class GuzzleProxy implements ClientInterface
      */
     public function request($method, $uri = '', array $options = [])
     {
-        $options = array_merge($options, $this->getOptions($method));
+        $options = array_merge_recursive($options, $this->getOptions($method));
 
         return $this->guzzleClient->request($method, $uri, $options);
     }
@@ -127,7 +127,7 @@ class GuzzleProxy implements ClientInterface
      */
     public function requestAsync($method, $uri = '', array $options = [])
     {
-        $options = array_merge($options, $this->getOptions($method));
+        $options = array_merge_recursive($options, $this->getOptions($method));
 
         return $this->guzzleClient->requestAsync($method, $uri, $options);
     }
@@ -140,7 +140,7 @@ class GuzzleProxy implements ClientInterface
      */
     public function sendAsync(RequestInterface $request, array $options = [])
     {
-        $options = array_merge($options, $this->getOptions($request->getMethod()));
+        $options = array_merge_recursive($options, $this->getOptions($request->getMethod()));
 
         return $this->guzzleClient->sendAsync($request, $options);
     }
@@ -153,7 +153,7 @@ class GuzzleProxy implements ClientInterface
      */
     public function send(RequestInterface $request, array $options = [])
     {
-        $options = array_merge($options, $this->getOptions($request->getMethod()));
+        $options = array_merge_recursive($options, $this->getOptions($request->getMethod()));
 
         return $this->guzzleClient->send($request, $options);
     }

--- a/src/Tests/Units/Guzzle/GuzzleProxy.php
+++ b/src/Tests/Units/Guzzle/GuzzleProxy.php
@@ -2,7 +2,6 @@
 
 namespace M6Web\Bundle\XRequestUidBundle\Tests\Units\Guzzle;
 
-use M6Web\Bundle\XRequestUidBundle\UniqId\UniqId;
 use mageekguy\atoum;
 use M6Web\Bundle\XRequestUidBundle\Guzzle\GuzzleProxy as TestedClass;
 
@@ -28,12 +27,11 @@ class GuzzleProxy extends atoum\test
     /**
      * @param string $method
      */
-    public function testMethod($method, $options = [])
+    public function testMethod($method, $options = [], $expectedOptions = [])
     {
         list($guzzleClient, $requestStack, $uniqId) = $this->getMocks();
 
         $guzzleClient->getMockController()->{$method} = null;
-        $options = array_merge($options, ['headers' => ['X-Request-Id' => '1234', 'X-RequestParentId' => 'ParentId']]);
 
         $this
             ->if($c = new TestedClass(
@@ -43,10 +41,10 @@ class GuzzleProxy extends atoum\test
                 'X-Request-Id',
                 'X-RequestParentId'
             ))
-            ->and($c->get($url = 'http://6play.fr'))
+            ->and($c->get($url = 'http://6play.fr', $options))
             ->mock($guzzleClient)
                 ->call('get')
-                    ->withArguments($url, $options)
+                    ->withArguments($url, $expectedOptions)
                         ->once()
         ;
     }
@@ -58,19 +56,77 @@ class GuzzleProxy extends atoum\test
     {
         return [
             [
-                'get'
+                'get',
+                [],
+                [
+                    'headers' => [
+                        'X-Request-Id' => '1234',
+                        'X-RequestParentId' => 'ParentId',
+                    ]
+                ]
             ],
             [
-                'send'
+                'send',
+                [],
+                [
+                    'headers' => [
+                        'X-Request-Id' => '1234',
+                        'X-RequestParentId' => 'ParentId',
+                    ]
+                ]
             ],
             [
-                'request'
+                'send',
+                [
+                    'headers' => [
+                        'super-header' => 'youpi'
+                    ]
+                ],
+                [
+                    'headers' => [
+                        'super-header' => 'youpi',
+                        'X-Request-Id' => '1234',
+                        'X-RequestParentId' => 'ParentId',
+                    ]
+                ]
+            ],
+            [
+                'request',
+                [],
+                [
+                    'headers' => [
+                        'X-Request-Id' => '1234',
+                        'X-RequestParentId' => 'ParentId',
+                    ]
+                ]
+            ],
+            [
+                'request',
+                [
+                    'headers' => [
+                        'super-header' => 'youpi'
+                    ]
+                ],
+                [
+                    'headers' => [
+                        'super-header' => 'youpi',
+                        'X-Request-Id' => '1234',
+                        'X-RequestParentId' => 'ParentId',
+                    ]
+                ]
             ],
             [
                 'get',
                 [
                     'headers' => [
                         'super-header' => 'youpi'
+                    ]
+                ],
+                [
+                    'headers' => [
+                        'super-header' => 'youpi',
+                        'X-Request-Id' => '1234',
+                        'X-RequestParentId' => 'ParentId',
                     ]
                 ]
             ]
@@ -92,7 +148,4 @@ class GuzzleProxy extends atoum\test
             $uniqId
         ];
     }
-
-
-
 }


### PR DESCRIPTION
### Why

If you defined a header in options on your request : 
```
$client->get('myurl',
[
   'headers' => [
        'foo => 'bar'
    ]
],
``` 
It will be erase on merge because we only merge the first array level with headers generated, so its return : 
`X-Request-Id` & `X-RequestParentId` header only

## How

Use `array_merge_recursive` instead of `array_merge`